### PR TITLE
bug fix: polling timestamp now ignores old registrations

### DIFF
--- a/apps/expo/src/components/routers/AppRouter.tsx
+++ b/apps/expo/src/components/routers/AppRouter.tsx
@@ -25,6 +25,16 @@ export default function AppRouter() {
       {isAuthed ? (
         <>
           <Tab.Screen
+            name="Home"
+            component={HomeRouter}
+            options={{
+              title: t("screens.home_stack.title"),
+              tabBarIcon: ({ color, size }) => {
+                return <Ionicons name="home-outline" size={size} color={color} />;
+              },
+            }}
+          />
+          <Tab.Screen
             name="DeviceOverview"
             component={DeviceOverviewScreen}
             options={{

--- a/apps/expo/src/hooks/device/useReceivingMeasurements.tsx
+++ b/apps/expo/src/hooks/device/useReceivingMeasurements.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { fetchDevice } from "@/api/device";
 import { Maybe } from "@/types";
 
-export default function useReceivingMeasurements(deviceName: string, retries = 5) {
+export default function useReceivingMeasurements(deviceName: string, retries = 5, openedTimestamp: Date) {
   const [count, setCount] = useState<number | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isError, setIsError] = useState(false);
@@ -20,8 +20,9 @@ export default function useReceivingMeasurements(deviceName: string, retries = 5
           const latestMeasurement = data?.latest_upload;
 
           console.log("latestTimestamp", latestMeasurement);
+          console.log("openedTimestamp", openedTimestamp);
 
-          if (latestMeasurement) {
+          if (latestMeasurement && latestMeasurement > openedTimestamp) {
             setLatestMeasurement(latestMeasurement);
             setIsLoading(false);
             setCount(null);

--- a/apps/expo/src/screens/home/ProvisionScreen.tsx
+++ b/apps/expo/src/screens/home/ProvisionScreen.tsx
@@ -33,7 +33,7 @@ export default function ProvisionScreen({ navigation, route }: ProvisionScreenPr
     isSuccess: isReceivingMeasurements,
     isError: isReceivingMeasurementsError,
     isLoading: isReceivingMeasurementsLoading,
-  } = useReceivingMeasurements(device.deviceName, 15);
+  } = useReceivingMeasurements(device.deviceName, 15, new Date());
 
   const { storeWifiNetwork } = useStoredWifiNetworks();
 


### PR DESCRIPTION
### Checklist

- [ x] Tests have been written/updated (if necessary)
  - [x ] All tests are passing
- [x ] Docs have been updated (if necessary)
- [x ] Updated `Linear` issue to `In Review`

### Description
This PR solves the following issue: 
Fix 4th tick after WiFi reset: upload date needs to be newer than time of reset

The heartbeat will now only be accepted if it is newer than the time on which setup started. This prevents old registrations from showing up. This means the same device can theoretically be used again without having to reset/fix it in the database.

### Linked Issues
https://trello.com/c/JQq083E2

### Additional context
iOS has been tested, please check if it works on Android.
