### PR TITLE
Building numbers measurements screen

### DIFF
--- a/apps/expo/src/components/routers/AppRouter.tsx
+++ b/apps/expo/src/components/routers/AppRouter.tsx
@@ -25,6 +25,16 @@ export default function AppRouter() {
       {isAuthed ? (
         <>
           <Tab.Screen
+            name="Home"
+            component={HomeRouter}
+            options={{
+              title: t("screens.home_stack.title"),
+              tabBarIcon: ({ color, size }) => {
+                return <Ionicons name="home-outline" size={size} color={color} />;
+              },
+            }}
+          />
+          <Tab.Screen
             name="DeviceOverview"
             component={DeviceOverviewScreen}
             options={{

--- a/apps/expo/src/screens/DeviceOverviewScreen/index.tsx
+++ b/apps/expo/src/screens/DeviceOverviewScreen/index.tsx
@@ -14,7 +14,6 @@ import Screen from "@/components/elements/Screen";
 import useTranslation from "@/hooks/translation/useTranslation";
 import { UserContext } from "@/providers/UserProvider";
 import { RootStackParamList, SettingsStackParamList } from "@/types/navigation";
-import { useNavigation, NavigationProp } from "@react-navigation/native";
 
 type DeviceOverviewScreenProps = NativeStackScreenProps<RootStackParamList, "DeviceOverview">;
 
@@ -23,7 +22,6 @@ export default function DeviceOverviewScreen({ navigation, route }: DeviceOvervi
   const { t } = useTranslation();
   const { user, isLoading } = useContext(UserContext);
   const bottomSheetRef = useRef<BottomSheetModal>(null);
-  const settingsNavigation = useNavigation<NavigationProp<SettingsStackParamList>>();
 
   const buildings = user?.buildings ?? [];
   const [buildingId, setBuildingId] = useState<number | undefined>(buildings[0]?.id);
@@ -66,9 +64,16 @@ export default function DeviceOverviewScreen({ navigation, route }: DeviceOvervi
             ) : null}
           </>
         )}
-        <View style={{ flexDirection: "row", justifyContent: "space-between", maxWidth: 300, width: "100%", }}>
-          <Button title={t("screens.device_overview.buttons.install_device")} onPress={() => navigation.navigate("Home")} />
-          <Button title={t("screens.device_overview.buttons.data_sources")} onPress={() => navigation.navigate("Settings")} />
+        <View style={{ flexDirection: "row", justifyContent: "space-between", maxWidth: "100%", width: "100%" }}>
+          <Button 
+            title={t("screens.device_overview.buttons.install_device")} 
+            onPress={() => navigation.navigate("Home")} 
+          />
+          <Button
+            title={t("screens.device_overview.buttons.data_sources")}
+            onPress={() => navigation.navigate('Settings', {screen:'ExternalProviderScreen'})
+          }
+          />        
         </View>
       </Box>
     </Screen >

--- a/apps/expo/src/screens/DeviceOverviewScreen/index.tsx
+++ b/apps/expo/src/screens/DeviceOverviewScreen/index.tsx
@@ -5,15 +5,15 @@ import { useContext, useRef, useState } from "react";
 import { TouchableOpacity, View } from "react-native";
 import Icon from "react-native-vector-icons/Ionicons";
 
-import BuildingBottomSheet from "../../components/common/bottomSheets/BuildingBottomSheet";
 import DeviceList from "./_deviceList";
+import BuildingBottomSheet from "../../components/common/bottomSheets/BuildingBottomSheet";
 
 import StatusIndicator from "@/components/common/StatusIndicator";
 import Box from "@/components/elements/Box";
 import Screen from "@/components/elements/Screen";
 import useTranslation from "@/hooks/translation/useTranslation";
 import { UserContext } from "@/providers/UserProvider";
-import { RootStackParamList, SettingsStackParamList } from "@/types/navigation";
+import { RootStackParamList } from "@/types/navigation";
 
 type DeviceOverviewScreenProps = NativeStackScreenProps<RootStackParamList, "DeviceOverview">;
 
@@ -64,18 +64,7 @@ export default function DeviceOverviewScreen({ navigation, route }: DeviceOvervi
             ) : null}
           </>
         )}
-        <View style={{ flexDirection: "row", justifyContent: "space-between", maxWidth: "100%", width: "100%" }}>
-          <Button 
-            title={t("screens.device_overview.buttons.install_device")} 
-            onPress={() => navigation.navigate("Home")} 
-          />
-          <Button
-            title={t("screens.device_overview.buttons.data_sources")}
-            onPress={() => navigation.navigate('Settings', {screen:'ExternalProviderScreen'})
-          }
-          />        
-        </View>
       </Box>
-    </Screen >
+    </Screen>
   );
 }

--- a/apps/expo/src/screens/MeasurementsScreen/index.tsx
+++ b/apps/expo/src/screens/MeasurementsScreen/index.tsx
@@ -84,7 +84,9 @@ export default function MeasurementsScreen() {
                 ? t("screens.device_overview.building_list.building_info.name", { id: buildingId })
                 : t("screens.device_overview.building_list.placeholder")}
             </Text>
-            <Icon name="chevron-down" size={16} />
+            {hasMultipleBuildings &&
+              <Icon name="chevron-down" size={16} />
+            }
           </TouchableOpacity>
           <TouchableOpacity
             disabled={deviceDropdownDisabled}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Checklist
- [X ] All tests are passing
- [X ] Docs have been updated (if necessary)
- [X ] Updated `Linear` issue to `In Review`

### Description

The app suggests a building number needs to be / may be selected, in situations where there is just one building associated with the account → don’t bother the user in this case, ditch the building selection GUI element in this case! (and should we ever need to bother about multiple buildings, then showing building numbers won’t cut it)

### Linked Issues 

https://trello.com/c/wvnPuAOJ

### Additional context

