### PR TITLE
Revert "build: use https to pull rn-esp-idf-provisioning"

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -53,7 +53,7 @@
     "react-native-bluetooth-state-manager": "1.3.4",
     "react-native-chart-kit": "6.12.0",
     "react-native-dotenv": "3.4.8",
-    "react-native-esp-idf-provisioning": "git+https://github.com/energietransitie/twomes-app-needforheat-eup.git",
+    "react-native-esp-idf-provisioning": "ssh://git@github.com/energietransitie/twomes-app-needforheat-eup",
     "react-native-exit-app": "^1.1.0",
     "react-native-gesture-handler": "2.8.0",
     "react-native-permissions": "3.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11459,9 +11459,9 @@ react-native-dotenv@3.4.8:
   dependencies:
     dotenv "^16.0.3"
 
-"react-native-esp-idf-provisioning@git+https://github.com/energietransitie/twomes-app-needforheat-eup.git":
+"react-native-esp-idf-provisioning@ssh://git@github.com/energietransitie/NeedForHeat-esp-idf-provisioning":
   version "0.1.0"
-  resolved "git+https://github.com/energietransitie/twomes-app-needforheat-eup.git#b4806311fbbe98fcccef583ef1b2181e68042bd8"
+  resolved "ssh://git@github.com/energietransitie/NeedForHeat-esp-idf-provisioning#b4806311fbbe98fcccef583ef1b2181e68042bd8"
 
 react-native-exit-app@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
This reverts commit c199a8b1f45e4cc291ee6801c2ffe5db1d5f73fc.

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Checklist

- [ ] Tests have been written/updated (if necessary)
  - [ ] All tests are passing
- [ ] Docs have been updated (if necessary)
- [ ] Updated `Linear` issue to `In Review`

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR solves the problem with CI. At least locally (using nektos/act) it works again with just this change. We will have to see if it also works on GitHub's action runners.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
