### PR TITLE
broaden terminology to cover Wi-Fi reset

### DIFF
--- a/apps/expo/src/lang/en-US.json
+++ b/apps/expo/src/lang/en-US.json
@@ -19,7 +19,7 @@
       "title": "Data Sources",
       "buttons": {
         "add_enelogic": "Connect Enelogic",
-        "install_device": "Add new device"
+        "install_device": "Scan device"
       },
       "device_list": {
         "device_info": {
@@ -85,7 +85,7 @@
         },
         "authenticated": {
           "title": "Scan a QR code",
-          "description": "Scan the QR code of a new measurement device. It can be found on the e-ink screen or on a sticker on (the back of) the device."
+          "description": "Scan the QR code of a measurement device. It can be found on the e-ink screen or on a sticker on (the back of) the device."
         },
         "unauthenticated": {
           "title": "NeedForHeat",

--- a/apps/expo/src/lang/nl-NL.json
+++ b/apps/expo/src/lang/nl-NL.json
@@ -18,8 +18,8 @@
     "device_overview": {
       "title": "Databronnen",
       "buttons": {
-        "add_enelogic": "Enelogic Toevoegen",
-        "install_device": "Apparaat Toevoegen"
+        "add_enelogic": "Enelogic toevoegen",
+        "install_device": "Meetapparaatje scannen"
       },
       "device_list": {
         "device_info": {
@@ -49,13 +49,13 @@
         "alert": {
           "unknown_error": "Er is een fout opgetreden bij het activeren van het apparaat.",
           "no_building": "Uw account is niet gekoppeld aan een gebouw.",
-          "already_activated": "Dit meetapparaat is al geactiveerd op een ander account."
+          "already_activated": "Dit meetapparaatje is al geactiveerd op een ander account."
         }
       },
       "already_invited": {
         "title": "Reeds uitgenodigd",
         "expanded_title": "Ik heb al een uitnodiging",
-        "description": "In de uitnodigingsmail die u heeft ontvangen staat een activatielink. Klik op deze link om te beginnen met de installatie van uw meetapparaten."
+        "description": "In de uitnodigingsmail die u heeft ontvangen staat een activatielink. Klik op deze link om te beginnen met de installatie van uw meetapparaatjes."
       },
       "add_device": {
         "title": "Apparaat verbinden",
@@ -85,7 +85,7 @@
         },
         "authenticated": {
           "title": "Scan een QR-code",
-          "description": "Scan de QR-code van een nieuw meetapparaatje. Deze staat op het e-ink scherm van het meetapparatje of op een sticker (kijk ook op de achterkant)."
+          "description": "Scan de QR-code van een meetapparaatje. Deze staat op het e-ink scherm van het meetapparaatje of op een sticker (kijk ook op de achterkant)."
         },
         "unauthenticated": {
           "title": "NeedForHeat",
@@ -237,7 +237,7 @@
         "app_language": "Taal selecteren",
         "wifi_passwords": {
           "title": "Opgeslagen wifiwachtwoorden verwijderen",
-          "message": "Weet u het zeker? Na het verwijderen van de opgeslagen wifiwachtwoorden uit deze app zult u bij het koppelen van een nieuw meetapparaat het wifiwachtwoord opnieuw moeten intypen.",
+          "message": "Weet u het zeker? Na het verwijderen van de opgeslagen wifiwachtwoorden uit deze app zult u bij het koppelen van een nieuw meetapparaatje het wifiwachtwoord opnieuw moeten intypen.",
           "toast": "wifiwachtwoorden succesvol verwijderd"
         },
         "session_token": {


### PR DESCRIPTION
### Checklist

- [ ] Tests have been written/updated (if necessary)
  - [ ] All tests are passing
- [ ] Docs have been updated (if necessary)
- [ ] Updated `Linear` issue to `In Review`

### Description

This PR includes two types of textual updates:
- broaden terminology in a few places to account for the fact that a button / screen is not only used for addin new devices, but also when scanning a device again for a Wi-Fi reset 
- consistently use the 'small' form "meetapparaatje"  to indicate a device in Dutch. 

### Additional context

This PR can be merged any time, but definitely should be merged before we make the version that goes to real subjects.