### PR TITLE
ci: fix build system

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -29,14 +29,14 @@ jobs:
           cache: yarn
 
       - name: Setup EAS
-        run: yarn global add expo-cli eas-cli
+        run: sudo yarn global add expo-cli eas-cli
 
       - uses: webfactory/ssh-agent@v0.7.0
         with:
           ssh-private-key: ${{ secrets.GH_SSH_KEY }}
 
       - name: Install dependencies
-        run: sudo yarn install --production
+        run: yarn install --production
 
       - name: Setup environment file
         run: |


### PR DESCRIPTION
I placed the sudo command in the wrong step.

Using sudo is necessary to install the eas command.