### PR TITLE
Text changes and build targets

### DIFF
--- a/apps/expo/ios/NeedforHeat.xcodeproj/project.pbxproj
+++ b/apps/expo/ios/NeedforHeat.xcodeproj/project.pbxproj
@@ -400,12 +400,9 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = nl.windesheim.energietransitie.warmtewachter;
 				PRODUCT_NAME = NeedforHeat;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -433,11 +430,8 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = nl.windesheim.energietransitie.warmtewachter;
 				PRODUCT_NAME = NeedforHeat;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/apps/expo/src/lang/en-US.json
+++ b/apps/expo/src/lang/en-US.json
@@ -19,7 +19,7 @@
       "title": "Data Sources",
       "buttons": {
         "add_enelogic": "Connect Enelogic",
-        "install_device": "Add new device"
+        "install_device": "Scan device"
       },
       "device_list": {
         "device_info": {
@@ -85,7 +85,7 @@
         },
         "authenticated": {
           "title": "Scan a QR code",
-          "description": "Scan the QR code of a new measurement device. It can be found on the e-ink screen or on a sticker on (the back of) the device."
+          "description": "Scan the QR code of a measurement device. It can be found on the e-ink screen or on a sticker on (the back of) the device."
         },
         "unauthenticated": {
           "title": "NeedForHeat",

--- a/apps/expo/src/lang/nl-NL.json
+++ b/apps/expo/src/lang/nl-NL.json
@@ -18,8 +18,8 @@
     "device_overview": {
       "title": "Databronnen",
       "buttons": {
-        "add_enelogic": "Enelogic Toevoegen",
-        "install_device": "Apparaat Toevoegen"
+        "add_enelogic": "Enelogic toevoegen",
+        "install_device": "Meetapparaatje scannen"
       },
       "device_list": {
         "device_info": {
@@ -49,13 +49,13 @@
         "alert": {
           "unknown_error": "Er is een fout opgetreden bij het activeren van het apparaat.",
           "no_building": "Uw account is niet gekoppeld aan een gebouw.",
-          "already_activated": "Dit meetapparaat is al geactiveerd op een ander account."
+          "already_activated": "Dit meetapparaatje is al geactiveerd op een ander account."
         }
       },
       "already_invited": {
         "title": "Reeds uitgenodigd",
         "expanded_title": "Ik heb al een uitnodiging",
-        "description": "In de uitnodigingsmail die u heeft ontvangen staat een activatielink. Klik op deze link om te beginnen met de installatie van uw meetapparaten."
+        "description": "In de uitnodigingsmail die u heeft ontvangen staat een activatielink. Klik op deze link om te beginnen met de installatie van uw meetapparaatjes."
       },
       "add_device": {
         "title": "Apparaat verbinden",
@@ -85,7 +85,7 @@
         },
         "authenticated": {
           "title": "Scan een QR-code",
-          "description": "Scan de QR-code van een nieuw meetapparaatje. Deze staat op het e-ink scherm van het meetapparatje of op een sticker (kijk ook op de achterkant)."
+          "description": "Scan de QR-code van een meetapparaatje. Deze staat op het e-ink scherm van het meetapparaatje of op een sticker (kijk ook op de achterkant)."
         },
         "unauthenticated": {
           "title": "NeedForHeat",
@@ -237,7 +237,7 @@
         "app_language": "Taal selecteren",
         "wifi_passwords": {
           "title": "Opgeslagen wifiwachtwoorden verwijderen",
-          "message": "Weet u het zeker? Na het verwijderen van de opgeslagen wifiwachtwoorden uit deze app zult u bij het koppelen van een nieuw meetapparaat het wifiwachtwoord opnieuw moeten intypen.",
+          "message": "Weet u het zeker? Na het verwijderen van de opgeslagen wifiwachtwoorden uit deze app zult u bij het koppelen van een nieuw meetapparaatje het wifiwachtwoord opnieuw moeten intypen.",
           "toast": "wifiwachtwoorden succesvol verwijderd"
         },
         "session_token": {

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -3,49 +3,37 @@
 When developing for iOS you need to have a Mac with Xcode and Ruby 3.1.0 installed. You can find more information about the setup [here](https://docs.expo.io/workflow/ios-simulator/).
 
 ## Ruby
-
 To install Cocoapods, Ruby is required. MacOS comes with a built-in version of Ruby that might not match the required version of this project. To install the correct version of Ruby, you can use `rbenv` using `homebrew`. If you don't have homebrew, you can learn more at [brew.sh](https://brew.sh/).
 
 To install `rbenv` you can run the following command:
-
 ```bash
 brew install rbenv
 ```
-
 Then, install the correct version of Ruby (3.1.0) using `rbenv`:
-
 ```bash
 rbenv install 3.1.0
 ```
-
 After installing Ruby, you can set the global version of Ruby to 3.1.0:
-
 ```bash
 rbenv global 3.1.0
 ```
-
 You can verify that the correct version of Ruby is installed by running:
-
 ```bash
 ruby -v
 ```
-
 This should output something along the lines of `ruby 3.1.0p0 (2021-12-25 revision 123456) [x86_64-darwin20]`.
 
 If this isn't the case, check where your Ruby version is coming from by running `which ruby`. If this is not the version you just installed, you can run `rbenv init` to get instructions on how to fix this.
 
 If that doesn't work, try eval
-
 ```bash
 eval "$(rbenv init -)"
 ```
-
 and then run `which ruby` again.
 
 ### Pods
 
 After installing Ruby correctly, you can install the required pods by running the following command in the `ios` directory:
-
 ```bash
 cd /apps/expo/ios
 
@@ -78,21 +66,3 @@ This means that specificly testing the `NeedForHeat` app that the simulator isn'
 > The CLI seems to be stuck when opening a Simulator
 
 Sometimes the iOS simulator doesn't respond to the open command. If it seems stuck on this prompt, you can open the iOS simulator manually `(open -a Simulator)` and then in the macOS toolbar, choose Hardware → Device, and select an iOS version and device that you'd like to open.
-
-> I get an error while building the app in Xcode or when running dev:ios
-
-If you get the following error:
-
-```bash
-❌  (ios/Pods/boost/boost/container_hash/hash.hpp:131:33)
-
-  129 | #else
-  130 |         template <typename T>
-> 131 |         struct hash_base : std::unary_function<T, std::size_t> {};
-      |                                 ^ no template named 'unary_function' in namespace 'std'; did you mean '__unary_function'?
-  132 | #endif
-  133 | 
-  134 |         struct enable_hash_value { typedef std::size_t type; };
-  ```
-  
-  Open up Xcode, execute a build, select the error that pops up and select 'Fix'. This will replace the `std::unary_function` with `std::__unary_function` and the build should succeed just fine. You'll also be able to run dev:ios again.

--- a/yarn.lock
+++ b/yarn.lock
@@ -11461,7 +11461,7 @@ react-native-dotenv@3.4.8:
 
 "react-native-esp-idf-provisioning@ssh://git@github.com/energietransitie/twomes-app-needforheat-eup":
   version "0.1.0"
-  resolved "ssh://git@github.com/energietransitie/twomes-app-needforheat-eup#b4806311fbbe98fcccef583ef1b2181e68042bd8"
+  resolved "ssh://git@github.com/energietransitie/twomes-app-needforheat-eup#a166a46ace76ca000d52c638de9072a993963bc8"
 
 react-native-exit-app@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
- Merge changes in text.
- Revert removing op iPad and Mac build targets.

The new version could not be submitted,
unless we create a new app in App Store Connect.

Any new version MUST support the same devices as the previous version.
See https://developer.apple.com/library/archive/qa/qa1623/_index.html.