### PR TITLE
fix upload date needs to be newer than time of reset

### DIFF
--- a/apps/expo/src/hooks/device/useReceivingMeasurements.tsx
+++ b/apps/expo/src/hooks/device/useReceivingMeasurements.tsx
@@ -3,11 +3,12 @@ import { useEffect, useState } from "react";
 import { fetchDevice } from "@/api/device";
 import { Maybe } from "@/types";
 
-export default function useReceivingMeasurements(deviceName: string, retries = 5, openedTimestamp: Date) {
+export default function useReceivingMeasurements(deviceName: string, retries = 10) {
   const [count, setCount] = useState<number | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isError, setIsError] = useState(false);
   const [latestMeasurement, setLatestMeasurement] = useState<Maybe<Date>>();
+  const [openedTimestamp, setOpenedTimestamp] = useState<Date>(new Date());
 
   useEffect(() => {
     if (count === null) return;

--- a/apps/expo/src/hooks/wifi/fetchEspNetworks.tsx
+++ b/apps/expo/src/hooks/wifi/fetchEspNetworks.tsx
@@ -3,4 +3,4 @@ import EspIdfProvisioning from "react-native-esp-idf-provisioning";
 import { WifiEntry } from "@/types";
 import { withTimeout } from "@/utils/withTimeout";
 
-export const fetchEspNetworks: () => Promise<WifiEntry[]> = () => withTimeout(10, EspIdfProvisioning.scanWifiList());
+export const fetchEspNetworks: () => Promise<WifiEntry[]> = () => withTimeout(30, EspIdfProvisioning.scanWifiList());

--- a/apps/expo/src/screens/home/ProvisionScreen.tsx
+++ b/apps/expo/src/screens/home/ProvisionScreen.tsx
@@ -33,7 +33,7 @@ export default function ProvisionScreen({ navigation, route }: ProvisionScreenPr
     isSuccess: isReceivingMeasurements,
     isError: isReceivingMeasurementsError,
     isLoading: isReceivingMeasurementsLoading,
-  } = useReceivingMeasurements(device.deviceName, 15, new Date());
+  } = useReceivingMeasurements(device.deviceName, 15);
 
   const { storeWifiNetwork } = useStoredWifiNetworks();
 


### PR DESCRIPTION
### Checklist

- [x] Tests have been written/updated (if necessary)
- [x] All tests are passing
- [x] Docs have been updated (if necessary)
- [x] Updated `Linear` issue to `In Review`

### Description
This PR solves the issue where the provision screen may never complete setup (not show 4th tick)