### PR TITLE
Back button not showing on Android and IOS on the add online data source screen.

### DIFF
--- a/apps/expo/src/components/routers/HomeRouter.tsx
+++ b/apps/expo/src/components/routers/HomeRouter.tsx
@@ -101,7 +101,6 @@ export default function HomeRouter() {
         name="AddOnlineDataSourceScreen"
         options={{
           title: t("screens.home_stack.provision.enelogic"),
-          ...disableNavigation,
         }}
         component={AddOnlineDataSourceScreen}
       />


### PR DESCRIPTION
### Checklist

- [ ] Tests have been written/updated (if necessary)
  - [ ] All tests are passing
- [ ] Docs have been updated (if necessary)
- [ ] Updated `Linear` issue to `In Review`

### Description

fix: Back button not showing on Android and IOS on the add online data source screen.

### Linked Issues


### Additional context

