### PR TITLE
Correct padding for the manual 

### DIFF
--- a/apps/expo/src/components/common/ManualContent/index.tsx
+++ b/apps/expo/src/components/common/ManualContent/index.tsx
@@ -26,13 +26,11 @@ export default function ManualContent({ manualUrl, languageHeader }: ManualConte
 
   return (
     <ScrollView
-      style={{ width: "100%" }}
+      style={{ width: "100%", marginLeft: "0%", paddingRight: "0%", paddingLeft: "0%" }}
       contentContainerStyle={{
         alignItems: "center",
         minHeight: "90%",
-        marginLeft: "2%",
-        paddingRight: "4%",
-        paddingLeft: "8%",
+        paddingHorizontal: "5%",
       }}
       persistentScrollbar
     >

--- a/apps/expo/src/screens/home/AddOnlineDataSourceScreen.tsx
+++ b/apps/expo/src/screens/home/AddOnlineDataSourceScreen.tsx
@@ -151,7 +151,7 @@ export default function AddOnlineDataSourceScreen({ navigation, route }: AddOnli
     return (
         <Box padded style={{ flex: 1 }}>
             <ManualContent manualUrl={MANUAL_URL + "enelogic/installation/generic/"} languageHeader={resolvedLanguage} />
-            <Box style={{ flexDirection: "column", marginTop: 16, width: "100%", justifyContent: 'center' }}>
+            <Box style={{ flexDirection: "column", marginTop: 16, width: "100%", justifyContent: 'center', alignItems: 'center' }}>
                 {data?.some((item) => !item.connected) && (
                     <Button
                         title={t("common.cancel")}


### PR DESCRIPTION
### Checklist

- [ ] Tests have been written/updated (if necessary)
  - [ ] All tests are passing
- [ ] Docs have been updated (if necessary)
- [ ] Updated `Linear` issue to `In Review`

### Description

Manual text is no longer cut off on the screen and text got equal padding on both sides.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
