### PR TITLE
fix: add base url to enable relative links

### DIFF
--- a/apps/expo/src/components/common/ManualContent/index.tsx
+++ b/apps/expo/src/components/common/ManualContent/index.tsx
@@ -41,7 +41,7 @@ export default function ManualContent({ manualUrl, languageHeader }: ManualConte
           <RenderHtml
             remoteErrorView={() => <RemoteErrorView />}
             remoteLoadingView={() => <RemoteLoadingView />}
-            source={{ uri: manualUrl, headers: headersObject }}
+            source={{ uri: manualUrl, headers: headersObject, baseUrl: manualUrl }}
             contentWidth={width}
           />
         </>


### PR DESCRIPTION
Relative links (`href="../../../faq"`) did not work correctly before, when clicking on them from a page rendered in the app (installation manuals).

See context [here](https://meliorence.github.io/react-native-render-html/docs/content/anchors#relative-urls).

I was unable to test this on a physical device, so can you please test this change? If you scan a living room module, you will see an FAQ link in the installation manual. You can use this link to test. 

Before the change, it would open in your device's browser: `https://manuals.energietransitiewindesheim.nl/faq`. 
It should open `https://manuals.energietransitiewindesheim.nl/devices/twomes-co2-occupancy-scd41-m5coreink-firmware/faq`. 
This will redirect to `https://manuals.energietransitiewindesheim.nl/devices/twomes-co2-occupancy-scd41-m5coreink-firmware/faq/manufacturer/<lang>`

Trello: https://trello.com/c/fIkqHwfw